### PR TITLE
Add space option to Standard and Mixed Scientific

### DIFF
--- a/src/mixed-scientific.ts
+++ b/src/mixed-scientific.ts
@@ -10,9 +10,9 @@ export class MixedScientificNotation extends Notation {
     return "Mixed scientific";
   }
 
-  public formatDecimal(value: Decimal, places: number): string {
+  public formatDecimal(value: Decimal, places: number, spaceStandard: boolean = true): string {
     if (value.exponent < 33) {
-      return standard.formatDecimal(value, places);
+      return standard.formatDecimal(value, places, spaceStandard);
     }
     const fixedValue = fixMantissaOverflow(value, places, 10, 1);
     const mantissa = fixedValue.mantissa.toFixed(places);

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -27,13 +27,13 @@ export class StandardNotation extends EngineeringNotation {
     return "Standard";
   }
 
-  public formatDecimal(value: Decimal, places: number): string {
+  public formatDecimal(value: Decimal, places: number, space: boolean = true): string {
     const engineering = toFixedEngineering(value, places);
     const mantissa = engineering.mantissa.toFixed(places);
     const abbreviation = engineering.exponent <= 303
       ? ABBREVIATIONS[engineering.exponent / 3]
       : this.abbreviate(engineering.exponent);
-    return `${mantissa} ${abbreviation}`;
+    return `${mantissa}${space ? " " : ""}${abbreviation}`;
   }
 
   private abbreviate(e: number): string {


### PR DESCRIPTION
Allows user to specify whether there is a space between the number and the abbreviation in Standard and Mixed Scientific notations.

I set it to true by default to make it backwards compatible since adding a space is the current behavior.