### PR TITLE
Implemented some basic Jasmine unit tests

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+exclude_paths:
+  - 'dist/**'
+  - 'spec/**/*'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "npm run build:ad && npm run build:community",
     "build:ad": "bili --config bili.config.base.ts && cp dist/ad-notations.min.js docs/ad-notations.min.js",
-    "build:community": "bili --config bili.config.community.ts && cp dist/ad-notations.community.min.js docs/ad-notations.community.min.js"
+    "build:community": "bili --config bili.config.community.ts && cp dist/ad-notations.community.min.js docs/ad-notations.community.min.js",
+    "test": "jasmine"
   },
   "main": "dist/ad-notations.umd.js",
   "module": "dist/ad-notations.esm.js",
@@ -36,8 +37,9 @@
     "@typescript-eslint/parser": "^4.2.0",
     "bili": "^5.0.2",
     "eslint": "^7.0.0",
+    "jasmine": "^3.6.1",
     "rollup-plugin-typescript2": "^0.27.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.3"
   },
   "dependencies": {
     "break_infinity.js": "^1.2.0",

--- a/spec/infix/infix-eng.spec.js
+++ b/spec/infix/infix-eng.spec.js
@@ -1,0 +1,57 @@
+// import { InfixEngineeringNotation } from '../../dist/ad-notations.community.esm.js';
+const { InfixEngineeringNotation } = require('../../dist/ad-notations.community.umd.js');
+
+describe("Infix engineering notation", function() {
+
+	const notation = new InfixEngineeringNotation();
+
+	it(" less than 1000, 0 places", function() {
+		expect(notation.format(3, 0)).toBe("3₀");
+		expect(notation.format(34, 0)).toBe("34₀");
+		expect(notation.format(345, 0)).toBe("345₀");
+		expect(notation.format(3.45, 0)).toBe("3₀");
+		expect(notation.format(34.6, 0)).toBe("35₀");
+		expect(notation.format(34.5, 0)).toBe("35₀");	// Is the rounding right??
+		expect(notation.format(33.5, 0)).toBe("34₀");	// Is the rounding right??
+		expect(notation.format(34.4, 0)).toBe("34₀");
+	});
+	it(" less than 1000, 1 places", function() {
+		expect(notation.format(3, 1)).toBe("3₀0");
+		expect(notation.format(34, 1)).toBe("34₀");
+		expect(notation.format(345, 1)).toBe("345₀");
+		expect(notation.format(3.45, 1)).toBe("3₀5");
+		expect(notation.format(34.5, 1)).toBe("35₀");
+	});
+	it(" less than 1000, 2 places", function() {
+		expect(notation.format(3, 2)).toBe("3₀00");
+		expect(notation.format(34, 2)).toBe("34₀0");
+		expect(notation.format(345, 2)).toBe("345₀");
+		expect(notation.format(3.45, 2)).toBe("3₀45");
+		expect(notation.format(34.5, 2)).toBe("34₀5");
+	});
+	it(" less than 1, 0 places", function() {
+		expect(notation.format(0.3, 0)).toBe("₀3");
+		expect(notation.format(0.34, 0)).toBe("₀3");
+		expect(notation.format(0.345, 0)).toBe("₀3");
+		expect(notation.format(0.3456, 0)).toBe("₀3");
+		expect(notation.format(0.01, 0)).toBe("10₋₃");
+		expect(notation.format(0.001, 0)).toBe("1₋₃00");	/// FIXME Is this one right? Should be 1₋₃
+		expect(notation.format(0.0001, 0)).toBe("100₋₆");
+		expect(notation.format(0.00001, 0)).toBe("10₋₆0");	/// FIXME Is this one right? Should be 10₋₆
+	});
+	it(" less than 1, 2 places", function() {
+		expect(notation.format(0.3, 2)).toBe("₀300₋₃");
+		expect(notation.format(0.34, 2)).toBe("₀340₋₃");
+		expect(notation.format(0.345, 2)).toBe("₀345₋₃");
+		expect(notation.format(0.3456, 2)).toBe("₀346₋₃");
+		expect(notation.format(0.003, 2)).toBe("3₋₃00");
+		expect(notation.format(0.0034, 2)).toBe("3₋₃40");
+		expect(notation.format(0.00345, 2)).toBe("3₋₃45");
+		expect(notation.format(0.003456, 2)).toBe("3₋₃46");
+	});
+	it(" more than 1e40, 0 places", function() {
+		expect(notation.format(3.45e40, 0)).toBe("34₃₉5");
+		expect(notation.format(34.5e40, 0)).toBe("345₃₉");
+		expect(notation.format(345e40, 0)).toBe("3₄₂45");
+	});
+});

--- a/spec/std/std.spec.js
+++ b/spec/std/std.spec.js
@@ -1,0 +1,24 @@
+// import { StandardNotation } from '../../dist/ad-notations.esm.js';
+const { StandardNotation } = require('../../dist/ad-notations.umd.js');
+
+describe("Standard notation", function() {
+
+	const notation = new StandardNotation();
+
+	it(" less than 1000, 0 places", function() {
+		expect(notation.format(3, 0, 0)).toBe("3");
+		expect(notation.format(34, 0, 0)).toBe("34");
+		expect(notation.format(345, 0, 0)).toBe("345");
+	});
+	it(" more than 1e40, 0 places", function() {
+		expect(notation.format(3.45e40, 0)).toBe("35 DDc");
+		expect(notation.format(34.5e40, 0)).toBe("345 DDc");
+		expect(notation.format(345e40, 0)).toBe("3 TDc");
+	});
+	it(" more than 1e40, 4 places", function() {
+		expect(notation.format(3.4567e40, 0)).toBe("35 DDc");
+		expect(notation.format(34.567e40, 0)).toBe("346 DDc");
+		expect(notation.format(345.67e40, 0)).toBe("3 TDc");
+		expect(notation.format(3456.7e40, 0)).toBe("35 TDc");
+	});
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true
+}


### PR DESCRIPTION
This PR implements some *basic* [jasmine](https://jasmine.github.io/index.html)-based tests. The goal is *not* to provide a comprehensive set of unit tests, but rather a basic scaffolding on when to build more tests (if/when deemed neccesary).

Why Jasmine and not Mocha/Cucumber/Chai/Jest/Karma? Personal preference. I tend to use Jasmine for small-ish projects and doesn't require a lot of set-up. It's also possible to set up a bit of HTML scaffolding to run the specs on a browser, but I don't think `notations` needs that at this point - there's hardly anything that is platform-dependent here.

Implements #97