### PR TITLE
[WIP] Add TypeScript declaration files to output

### DIFF
--- a/bili.config.base.ts
+++ b/bili.config.base.ts
@@ -3,9 +3,14 @@ import type { Config } from "bili";
 const config: Config = {
   plugins: {
     typescript2: {
+      useTsconfigDeclarationDir: true,
       tsconfigOverride: {
         include: ["src"],
-        exclude: ["**/*.test.ts"]
+        exclude: ["**/*.test.ts"],
+        compilerOptions: {
+          declaration: true,
+          declarationDir: "./dist/types"
+        }
       }
     }
   },

--- a/bili.config.community.ts
+++ b/bili.config.community.ts
@@ -3,9 +3,14 @@ import type { Config } from "bili";
 const config: Config = {
   plugins: {
     typescript2: {
+      useTsconfigDeclarationDir: true,
       tsconfigOverride: {
         include: ["src"],
-        exclude: ["**/*.test.ts"]
+        exclude: ["**/*.test.ts"],
+        compilerOptions: {
+          declaration: true,
+          declarationDir: "./dist/types"
+        }
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "module": "dist/ad-notations.esm.js",
   "unpkg": "dist/ad-notations.umd.js",
   "jsdelivr": "dist/ad-notations.umd.js",
+  "types": "dist/types/index.d.ts",
   "keywords": [
     "notations",
     "numbers"


### PR DESCRIPTION
This PR introduces declaration files to the output. The changes include:

1. Adding a TSConfig override in the Bili config to allow for declaration files to be generated and are then generated in `./dist/types`.
2. Adding the necessary JSON properties to `package.json` such that the TS compiler can detect the declaration files (as indicated in the [TypeScript docs for publishing declaration files](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package)).

## Caveats

The typings currently don't include the community notations.

## Additional notes

- Could the notations be potentially used on their own in the future?
- I've fixed an issue in `src/community/infix-abstract.ts` which broke the build
- Here's a preview of what the output would be:

<img alt="Screenshot of the output directory" src="https://user-images.githubusercontent.com/20047125/112762701-acb1d700-9033-11eb-9f89-895b7517e21b.jpg" width="200">

Closes #150