### PR TITLE
Should hopefully solve exponents being wonky

### DIFF
--- a/src/notation.ts
+++ b/src/notation.ts
@@ -86,6 +86,8 @@ export abstract class Notation {
       // need this to use specialformat first
       return formatWithCommas(specialFormat(exponent, 0));
     }
-    return this.formatDecimal(new Decimal(exponent), precision);
+    // We want at least two Decimal points on exponents- Numbers like 1e1.5e12 should still get formatted as 1e1.50e12,
+    // not 1e2e12 even if the precision specified is 0. Exponents are needed in more precision than mantissas.
+    return this.formatDecimal(new Decimal(exponent), Math.max(precision, 2));
   }
 }


### PR DESCRIPTION
Most notably, `format("1e1.5e12", 0)` for example might return "1e2e12", while `format("1.4e12", 0)` might return "1e1e12".
Example given in Scientific Notation.
This is significant for things like cost requirements- Having 1.00e1.00e12 antimatter and not being able to afford something claiming to require "1e1e12", or having 1.00e1.50e12 antimatter and being able to afford something claiming to require "1e2e12" is confusing. However, adding two precision points to the upgrade requirements may cause unnecessary bloat.
(Hopefully) Resolve #328