### PR TITLE
feat: implement typescript declaration files

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,17 @@
+name: Test build steps
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-node@v1
+    - run: npm install
+    - run: npm run build
+    

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules/
 
 # Generated output
 dist
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antimatter-dimensions/notations",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Notations used in Antimatter Dimensions",
   "scripts": {
     "build": "npm run build:ad && npm run build:community",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "description": "Notations used in Antimatter Dimensions",
   "scripts": {
-    "build": "npm run build:ad && npm run build:community",
+    "build": "tsc && npm run build:ad && npm run build:community",
     "build:ad": "bili --config bili.config.base.ts && cp dist/ad-notations.min.js docs/ad-notations.min.js",
     "build:community": "bili --config bili.config.community.ts && cp dist/ad-notations.community.min.js docs/ad-notations.community.min.js",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "module": "dist/ad-notations.esm.js",
   "unpkg": "dist/ad-notations.umd.js",
   "jsdelivr": "dist/ad-notations.umd.js",
+  "types": "dist/types",
   "keywords": [
     "notations",
     "numbers"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import Decimal from "break_infinity.js";
-import { Settings } from "./settings.js";
+import { Settings } from "./settings";
 
 function commaSection(value: string, index: number): string {
   if (index === 0) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__/*"],
   "compilerOptions": {
     "target": "es5",
     "incremental": true,
@@ -8,6 +10,10 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src/",
+    "outDir": "./dist/types"
   }
 }


### PR DESCRIPTION
This pull request aims to close issue #150 and replace pull request #204. To do this, we can simply use the native TypeScript compiler to generate the declaration files, which seems to work pretty much identically to the `bili` changes used in #204, but it (to me) feels a bit more natural.

I guess the other thing that would need to be figured out before this is merged is how we want community notations to work. Currently, they are made to be installed separately from the main package, which is mostly fine for most use cases. It becomes a bit more complicated when there are types involved (and if somebody wanted to use the community notations in, say, a React/Vue application that wants to use the NPM versions of the packages).

*As a note: the `build-test.yml` file can be removed; it was simply how I tested that the build wouldn't fail because it wasn't working on my machine.*